### PR TITLE
Add PNG download option

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,12 +62,6 @@
             display: block;
         }
 
-        #saveas, #saveaspng {
-            font-size: 30px;
-            margin-top: 15px;
-            /*display: block;*/
-        }
-
         #noise-control {
             margin-top: 120px;
             font-size: 20px;


### PR DESCRIPTION
Adds basic PNG download link by writing the SVG to an invisible canvas and generating a PNG data URI. This only changes the index page, and not trianglify,js, but the same approach could be added there if desired.

Might be broken for older browsers due to restrictions on tainted canvases, but I suspect supporting them would require a totally different approach..?
