### PR TITLE
Extract point generation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -143,6 +143,10 @@ var pattern = Trianglify({color_function: colorFunc})
 
 Number, defaults to `1.51`. Specify the width of the stroke on triangle shapes in the pattern. The default value is the ideal value for eliminating antialiasing artifacts when rendering patterns to a canvas.
 
+### points
+
+Array of points ([x, y]) to trianglulate. When not specified an array randomised points is generated filling the space.
+
 # License
 
 Trianglify is GPLv3 licensed. Please [contact me](mailto:qr@qrohlf.com) if you are interested in purchasing Trianglify under an alternative license.

--- a/examples/cutom-points-example.html
+++ b/examples/cutom-points-example.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Trianglify custom points example</title>
+    <style>
+    html, body {
+      margin: 0 0;
+      padding: 0 0;
+      text-align: center;
+      font-size: 0;
+    }
+    </style>
+  </head>
+  <body>
+  <script src="../dist/trianglify.min.js"></script>
+  <script>
+
+  var h = window.innerHeight, w = window.innerWidth;
+  var center_y = h * 0.5, center_x = w * 0.5;
+  
+  var points = [];
+  var spacing = 20;
+  var t = 0;
+  // generate a sine wave of points
+  for(var x = spacing; x < w - (spacing*2); x += spacing) {
+	var y = center_y + Math.sin(t) * (center_y - spacing);
+	points.push([x, y]);
+	t += 0.5;
+  }
+
+  // set up the base pattern
+  var pattern = Trianglify({
+    height: h,
+    width: w,
+    points: points,
+    cell_size: 30 + Math.random() * 100})
+
+  // canvas
+  document.body.appendChild(pattern.canvas())
+
+  // svg
+  document.body.appendChild(pattern.svg())
+
+  // png
+  var png = document.createElement('img')
+  png.src = pattern.png()
+  document.body.appendChild(png)
+  </script>
+  </body>
+</html>

--- a/lib/points.js
+++ b/lib/points.js
@@ -1,0 +1,43 @@
+function generate_grid(width, height, bleed_x, bleed_y, cell_size, variance, rand_fn) {
+  var w = width + bleed_x;
+  var h = height + bleed_y;
+  var half_cell_size = cell_size * 0.5;
+  var double_v = variance * 2;
+  var negative_v = -variance;
+
+  var points = [];
+  for (var i = -bleed_x; i < w; i += cell_size) {
+    for (var j = -bleed_y; j < h; j += cell_size) {
+      var x = (i + half_cell_size) + (rand_fn() * double_v + negative_v);
+      var y = (j + half_cell_size) + (rand_fn() * double_v + negative_v);
+      points.push([Math.floor(x), Math.floor(y)]);
+    }
+  }
+
+  return points;
+}
+
+function _map(num, in_range, out_range ) {
+    return ( num - in_range[0] ) * ( out_range[1] - out_range[0] ) / ( in_range[1] - in_range[0] ) + out_range[0];
+}
+
+// generate points on a randomized grid
+function _generate_points(width, height, bleed_x, bleed_y, opts, variance, rand) {
+
+	var points = [];
+	for (var i = - bleed_x; i < width + bleed_x; i += opts.cell_size) {
+	  for (var j = - bleed_y; j < height + bleed_y; j += opts.cell_size) {
+	    var x = i + opts.cell_size/2 + _map(rand(), [0, 1], [-variance, variance]);
+	    var y = j + opts.cell_size/2 + _map(rand(), [0, 1], [-variance, variance]);
+	    points.push([x, y].map(Math.floor));
+	  }
+	}
+
+	return points;
+}
+
+
+module.exports = {
+	generateGrid: generate_grid,
+	generatePoints: _generate_points
+};

--- a/lib/points.js
+++ b/lib/points.js
@@ -17,27 +17,4 @@ function generate_grid(width, height, bleed_x, bleed_y, cell_size, variance, ran
   return points;
 }
 
-function _map(num, in_range, out_range ) {
-    return ( num - in_range[0] ) * ( out_range[1] - out_range[0] ) / ( in_range[1] - in_range[0] ) + out_range[0];
-}
-
-// generate points on a randomized grid
-function _generate_points(width, height, bleed_x, bleed_y, opts, variance, rand) {
-
-	var points = [];
-	for (var i = - bleed_x; i < width + bleed_x; i += opts.cell_size) {
-	  for (var j = - bleed_y; j < height + bleed_y; j += opts.cell_size) {
-	    var x = i + opts.cell_size/2 + _map(rand(), [0, 1], [-variance, variance]);
-	    var y = j + opts.cell_size/2 + _map(rand(), [0, 1], [-variance, variance]);
-	    points.push([x, y].map(Math.floor));
-	  }
-	}
-
-	return points;
-}
-
-
-module.exports = {
-	generateGrid: generate_grid,
-	generatePoints: _generate_points
-};
+module.exports = generate_grid;

--- a/lib/trianglify.js
+++ b/lib/trianglify.js
@@ -9,6 +9,7 @@ var delaunay = require('delaunay-fast');
 var seedrandom = require('seedrandom');
 var chroma = require('chroma-js'); //PROBLEM: chroma.js is nearly 32k in size
 var colorbrewer = require('./colorbrewer'); //We could use the chroma.js colorbrewer, but it's got some ugly stuff so we use our own subset.
+var point_gen = require('./points');
 
 var Pattern = require('./pattern');
 
@@ -98,7 +99,7 @@ function Trianglify(opts) {
   };
 
   // generate a point mesh
-  var points = _generate_points(width, height);
+  var points = point_gen.generateGrid(width, height, bleed_x, bleed_y, opts.cell_size, variance, rand);
 
   // delaunay.triangulate gives us indices into the original coordinate array
   var geom_indices = delaunay.triangulate(points);
@@ -123,21 +124,6 @@ function Trianglify(opts) {
 
   function _map(num, in_range, out_range ) {
     return ( num - in_range[0] ) * ( out_range[1] - out_range[0] ) / ( in_range[1] - in_range[0] ) + out_range[0];
-  }
-
-  // generate points on a randomized grid
-  function _generate_points(width, height) {
-
-    var points = [];
-    for (var i = - bleed_x; i < width + bleed_x; i += opts.cell_size) {
-      for (var j = - bleed_y; j < height + bleed_y; j += opts.cell_size) {
-        var x = i + opts.cell_size/2 + _map(rand(), [0, 1], [-variance, variance]);
-        var y = j + opts.cell_size/2 + _map(rand(), [0, 1], [-variance, variance]);
-        points.push([x, y].map(Math.floor));
-      }
-    }
-
-    return points;
   }
 
   //triangles only!

--- a/lib/trianglify.js
+++ b/lib/trianglify.js
@@ -24,7 +24,8 @@ var defaults = {
   palette: colorbrewer,             // Palette to use for 'random' color option
   color_space: 'lab',               // Color space used for gradient construction & interpolation
   color_function: null,             // Color function f(x, y) that returns a color specification that is consumable by chroma-js
-  stroke_width: 1.51                // Width of stroke. Defaults to 1.51 to fix an issue with canvas antialiasing.
+  stroke_width: 1.51,               // Width of stroke. Defaults to 1.51 to fix an issue with canvas antialiasing.
+  points: undefined                 // An Array of [x,y] coordinates to trianglulate. Defaults to undefined, and points are generated.
 };
 
 /*********************************************************
@@ -99,7 +100,7 @@ function Trianglify(opts) {
   };
 
   // generate a point mesh
-  var points = point_gen.generateGrid(width, height, bleed_x, bleed_y, opts.cell_size, variance, rand);
+  var points = opts.points || point_gen.generateGrid(width, height, bleed_x, bleed_y, opts.cell_size, variance, rand);
 
   // delaunay.triangulate gives us indices into the original coordinate array
   var geom_indices = delaunay.triangulate(points);

--- a/lib/trianglify.js
+++ b/lib/trianglify.js
@@ -9,7 +9,7 @@ var delaunay = require('delaunay-fast');
 var seedrandom = require('seedrandom');
 var chroma = require('chroma-js'); //PROBLEM: chroma.js is nearly 32k in size
 var colorbrewer = require('./colorbrewer'); //We could use the chroma.js colorbrewer, but it's got some ugly stuff so we use our own subset.
-var point_gen = require('./points');
+var _generate_points = require('./points');
 
 var Pattern = require('./pattern');
 
@@ -100,7 +100,7 @@ function Trianglify(opts) {
   };
 
   // generate a point mesh
-  var points = opts.points || point_gen.generateGrid(width, height, bleed_x, bleed_y, opts.cell_size, variance, rand);
+  var points = opts.points || _generate_points(width, height, bleed_x, bleed_y, opts.cell_size, variance, rand);
 
   // delaunay.triangulate gives us indices into the original coordinate array
   var geom_indices = delaunay.triangulate(points);

--- a/test/test.js
+++ b/test/test.js
@@ -118,17 +118,17 @@ describe('Pattern', function() {
 
 describe('Points', function() {
   var points = require('../lib/points');
-  describe('#generateGrid', function() {
-    it('generates the correct number of points', function() {
+  describe('#_generate_points', function() {
+    it('generates points', function() {
         var width = 400, height = 200, cell_size = 75, variance = 0.75, bleed_x = 1, bleed_y = 1;
-        var opts = {cell_size: cell_size};
         var rand_fn = function(val){ return 4; };
 
-        var newAlgo = points.generateGrid(width, height, bleed_x, bleed_y, cell_size, variance, rand_fn);
-        var oldAlgo = points.generatePoints(width, height, bleed_x, bleed_y, opts, variance, rand_fn);
+        var generatedPoints = points(width, height, bleed_x, bleed_y, cell_size, variance, rand_fn);
+        var examplePoint = generatedPoints[0];
 
-        newAlgo.length.should.eql(oldAlgo.length);
-        newAlgo.should.eql(oldAlgo);
+        generatedPoints.should.be.instanceof(Array);
+        examplePoint.should.be.instanceof(Array);
+        examplePoint.should.have.length(2);
     });
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -115,3 +115,20 @@ describe('Pattern', function() {
     });
   });
 });
+
+describe('Points', function() {
+  var points = require('../lib/points');
+  describe('#generateGrid', function() {
+    it('generates the correct number of points', function() {
+        var width = 400, height = 200, cell_size = 75, variance = 0.75, bleed_x = 1, bleed_y = 1;
+        var opts = {cell_size: cell_size};
+        var rand_fn = function(val){ return 4; };
+
+        var newAlgo = points.generateGrid(width, height, bleed_x, bleed_y, cell_size, variance, rand_fn);
+        var oldAlgo = points.generatePoints(width, height, bleed_x, bleed_y, opts, variance, rand_fn);
+
+        newAlgo.length.should.eql(oldAlgo.length);
+        newAlgo.should.eql(oldAlgo);
+    });
+  });
+});


### PR DESCRIPTION
Enables specifying a custom array of points (see the custom-points-example.html) for users who may want to provide their own point generation.

Additionally, I refactored the code required to generate points to inline the _map function for performance reasons, this jsbin highlights the difference:
http://jsbin.com/helihu/4/edit?js,output

One of these commits includes a test to validate that the optimization produces the same result, it is then subsequently removed in a further commit. I leave this in the history in case a re-validation is required.