### PR TITLE
Avoid false positives in Node environment check

### DIFF
--- a/lib/pattern.js
+++ b/lib/pattern.js
@@ -33,7 +33,9 @@ function Pattern(polys, opts) {
   function render_canvas(canvas) {
     // check for canvas support
     var ctx;
-    if (typeof process === 'object' && typeof process.versions === 'object' && typeof process.versions.node !== 'undefined')
+    if (typeof process === 'object' && 
+        typeof process.versions === 'object' && 
+        typeof process.versions.node !== 'undefined') {
       // In Node environment.
       try {
         require('canvas');

--- a/lib/pattern.js
+++ b/lib/pattern.js
@@ -33,7 +33,8 @@ function Pattern(polys, opts) {
   function render_canvas(canvas) {
     // check for canvas support
     var ctx;
-    if (typeof process !== "undefined") {
+    if (typeof process !== "undefined" && process.title.indexOf('node') > -1) {
+      // In Node environment.
       try {
         require('canvas');
       } catch (e) {

--- a/lib/pattern.js
+++ b/lib/pattern.js
@@ -33,7 +33,7 @@ function Pattern(polys, opts) {
   function render_canvas(canvas) {
     // check for canvas support
     var ctx;
-    if (typeof process !== "undefined" && process.title.indexOf('node') > -1) {
+    if (typeof process === 'object' && typeof process.versions === 'object' && typeof process.versions.node !== 'undefined')
       // In Node environment.
       try {
         require('canvas');


### PR DESCRIPTION
I'm working with a browser environment where the `process` global variable is defined. The Node check should be a little more specific to avoid false positives.