### PR TITLE
Fixed: TypeError: Cannot read property 'canvas' of undefined

### DIFF
--- a/lib/pattern.js
+++ b/lib/pattern.js
@@ -45,10 +45,22 @@ function Pattern(polys, opts) {
       }
     }
 
+    var oldCanvas = typeof canvasLib.createCanvas === 'undefined';
+
     if (!canvas) {
-      canvas = canvasLib.createCanvas();
+      if (oldCanvas) {
+        // canvas 1.x
+        canvas = doc.createElement('canvas');
+      } else {
+        // canvas 2.x
+        canvas = canvasLib.createCanvas();
+      }
     }
 
+    if (oldCanvas) {
+      canvas.setAttribute('width', opts.width);
+      canvas.setAttribute('height', opts.height);
+    }
     ctx = canvas.getContext("2d");
     ctx.canvas.width = opts.width;
     ctx.canvas.height = opts.height;

--- a/lib/pattern.js
+++ b/lib/pattern.js
@@ -33,23 +33,22 @@ function Pattern(polys, opts) {
   function render_canvas(canvas) {
     // check for canvas support
     var ctx;
+    var canvasLib;
     if (typeof process === 'object' && 
         typeof process.versions === 'object' && 
         typeof process.versions.node !== 'undefined') {
       // In Node environment.
       try {
-        require('canvas');
+        canvasLib = require('canvas');
       } catch (e) {
         throw Error('The optional node-canvas dependency is needed for Trianglify to render using canvas in node.');
       }
     }
 
     if (!canvas) {
-      canvas = doc.createElement('canvas');
+      canvas = canvasLib.createCanvas();
     }
 
-    canvas.setAttribute('width', opts.width);
-    canvas.setAttribute('height', opts.height);
     ctx = canvas.getContext("2d");
     ctx.canvas.width = opts.width;
     ctx.canvas.height = opts.height;


### PR DESCRIPTION
The error occured on NodeJS8 on MacOS Mojave with canvas2.0