### PR TITLE
Fixed: Nodejs API updates information about Buffer

### DIFF
--- a/examples/save-as-png.js
+++ b/examples/save-as-png.js
@@ -22,7 +22,7 @@ var pngURI = Trianglify({
 var data = pngURI.substr(pngURI.indexOf('base64') + 7);
 
 // Decode the base64 encoded blob into a buffer
-var buffer = new Buffer(data, 'base64');
+var buffer = new Buffer.from(data, 'base64');
 
 // Save the buffer to a file
 fs.writeFileSync(process.argv[2], buffer);


### PR DESCRIPTION
Nodejs API updates information about Buffer

`new Buffer()` change to `new Buffer.from()`

and detail information see: [NodeJs document](https://nodejs.org/docs/latest/api/buffer.html#buffer_buffer_from_buffer_alloc_and_buffer_allocunsafe)