### PR TITLE
close the canvas path to avoid random white gaps

### DIFF
--- a/lib/pattern.js
+++ b/lib/pattern.js
@@ -61,6 +61,7 @@ function Pattern(polys, opts) {
       ctx.moveTo.apply(ctx, poly[1][0]);
       ctx.lineTo.apply(ctx, poly[1][1]);
       ctx.lineTo.apply(ctx, poly[1][2]);
+      ctx.lineTo.apply(ctx, poly[1][0]);
       ctx.fill();
       ctx.stroke();
     });


### PR DESCRIPTION
The path on canvas should be closed to avoid random white gaps between the shapes.