### PR TITLE
close canvas path to avoid random white gaps

### DIFF
--- a/lib/pattern.js
+++ b/lib/pattern.js
@@ -61,6 +61,7 @@ function Pattern(polys, opts) {
       ctx.moveTo.apply(ctx, poly[1][0]);
       ctx.lineTo.apply(ctx, poly[1][1]);
       ctx.lineTo.apply(ctx, poly[1][2]);
+      ctx.lineTo.apply(ctx, poly[1][0]);
       ctx.fill();
       ctx.stroke();
     });


### PR DESCRIPTION
Some white lines exist between triangle shapes when drawing on canvas. Just close the path.