### PR TITLE
make round corner of triangle shapes on canvas

### DIFF
--- a/lib/pattern.js
+++ b/lib/pattern.js
@@ -57,6 +57,7 @@ function Pattern(polys, opts) {
     polys.forEach(function(poly) {
       ctx.fillStyle = ctx.strokeStyle = poly[0];
       ctx.lineWidth = opts.stroke_width;
+      ctx.lineJoin = 'round';
       ctx.beginPath();
       ctx.moveTo.apply(ctx, poly[1][0]);
       ctx.lineTo.apply(ctx, poly[1][1]);


### PR DESCRIPTION
For wide storke with default 'miter' lineJoin style on canvas, some very pointed shape corners may be cut by neighbours, and cause isolated color points. 

cell_size = 1000, stroke_width = 20, default miter lineJoin 
![trianglify-2 0 0-canvas-wide-before-0](https://user-images.githubusercontent.com/1175717/57207960-72845a00-7003-11e9-8ed9-ace98e30e655.png)

The 'round' lineJoin style fix this problem.

cell_size = 1000, stroke_width = 20, round lineJoin
![trianglify-2 0 0-canvas-wide-after](https://user-images.githubusercontent.com/1175717/57207977-9a73bd80-7003-11e9-9cbf-ae984b70e16a.png)

And, especially with option 'stroke_color' proposed by @EpicKris in #91, amazing images like mosaic-pattern or porcelain-open can be made.

cell_size = 1000, stroke_width = 20, stroke_color = '#333333'
![trianglify-2 0 0-canvas-wide](https://user-images.githubusercontent.com/1175717/57207712-e0c81d00-7001-11e9-9f34-2a5ecad25921.png)

cell_size = 50, stroke_width = 2, stroke_color = '#333333'
![trianglify-2 0 0-canvas-round](https://user-images.githubusercontent.com/1175717/57207734-ffc6af00-7001-11e9-87a5-bf70f243071b.png)
