### PR TITLE
docs: Fix simple typo, trianglulate -> triangulate

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -154,4 +154,4 @@ Number, defaults to `1.51`. Specify the width of the stroke on triangle shapes i
 
 ### points
 
-Array of points ([x, y]) to trianglulate. When not specified an array randomised points is generated filling the space.
+Array of points ([x, y]) to triangulate. When not specified an array randomised points is generated filling the space.

--- a/lib/trianglify.js
+++ b/lib/trianglify.js
@@ -25,7 +25,7 @@ var defaults = {
   color_space: 'lab',               // Color space used for gradient construction & interpolation
   color_function: null,             // Color function f(x, y) that returns a color specification that is consumable by chroma-js
   stroke_width: 1.51,               // Width of stroke. Defaults to 1.51 to fix an issue with canvas antialiasing.
-  points: undefined                 // An Array of [x,y] coordinates to trianglulate. Defaults to undefined, and points are generated.
+  points: undefined                 // An Array of [x,y] coordinates to triangulate. Defaults to undefined, and points are generated.
 };
 
 /*********************************************************


### PR DESCRIPTION
There is a small typo in Readme.md, lib/trianglify.js.

Should read `triangulate` rather than `trianglulate`.

