### PR TITLE
shapeRendering option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -197,7 +197,8 @@ const defaultOptions = {
   colorSpace: 'lab',
   colorFunction: trianglify.colorFunctions.interpolateLinear(0.5),
   strokeWidth: 0,
-  points: null
+  points: null,
+  shapeRendering: 'crispEdges'
 }
 ```
 
@@ -258,3 +259,9 @@ Number, defaults to 0. Specify the width of the strokes used to outline the poly
 **`points`**
 
 Array of points ([x, y]) to triangulate, defaults to null. When not specified an array randomised points is generated filling the space. Points must be within the coordinate space defined by `width` and `height`. See [`examples/custom-points-example.html`](./examples/custom-points-example.html) for a demonstration of how this option can be used to generate circular trianglify patterns.
+
+
+**`shapeRendering`**
+
+String or False, defaults to `'crispEdges'`. Provides a hint to the SVG user agent about how to optimize its shape rendering. False won't render this attribute into result SVG.
+

--- a/src/pattern.js
+++ b/src/pattern.js
@@ -63,7 +63,7 @@ export default class Pattern {
         stroke: hasStroke ? poly.color.css() : undefined,
         'stroke-width': hasStroke ? opts.strokeWidth : undefined,
         'stroke-linejoin': hasStroke ? 'round' : undefined,
-        'shape-rendering': opts.fill ? 'crispEdges' : undefined
+        'shape-rendering': opts.fill ? opts.shapeRendering || undefined : undefined
       })
     })
 

--- a/src/trianglify.js
+++ b/src/trianglify.js
@@ -29,7 +29,8 @@ const defaultOptions = {
   colorFunction: colorFunctions.interpolateLinear(0.5),
   fill: true,
   strokeWidth: 0,
-  points: null
+  points: null,
+  shapeRendering: 'crispEdges'
 }
 
 // This function does the "core" render-independent work:


### PR DESCRIPTION
Allow to set `shape-rendering` attribute for SVG nodes. The goal is let user define how what to use, because `crispEdges` value produces really [bad results](https://coderwall.com/p/ufldzw/for-crisp-edges-use-anything-but-crispedges).

This PR doesn't change default SVG rendering for v.4.x. But maybe better to set this newly created option to `false` by default.
